### PR TITLE
Add an Entity Targeting System

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     compileOnly("com.github.Project-Cepi:Minestom:20ed4926c8")
 
     // implement KStom
-    compileOnly("com.github.Project-Cepi:KStom:70f33e42a0")
+    compileOnly("com.github.Project-Cepi:KStom:62ae2ba71f")
 
     // import kotlinx serialization
     compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.0")

--- a/src/main/kotlin/world/cepi/itemextension/ItemExtension.kt
+++ b/src/main/kotlin/world/cepi/itemextension/ItemExtension.kt
@@ -7,7 +7,6 @@ import world.cepi.itemextension.combat.TargetHandler
 import world.cepi.itemextension.combat.events.*
 import world.cepi.itemextension.command.ClearCommand
 import world.cepi.itemextension.command.GiveCommand
-import world.cepi.itemextension.command.SpawnZombieCommand
 import world.cepi.itemextension.command.itemcommand.ItemCommand
 import world.cepi.itemextension.stats.StatsHandler
 
@@ -32,7 +31,6 @@ object ItemExtension : Extension() {
         MinecraftServer.getCommandManager().register(ItemCommand)
         MinecraftServer.getCommandManager().register(ClearCommand)
         MinecraftServer.getCommandManager().register(GiveCommand)
-        MinecraftServer.getCommandManager().register(SpawnZombieCommand())
 
         logger.info("[ItemExtension] has been enabled!")
     }

--- a/src/main/kotlin/world/cepi/itemextension/ItemExtension.kt
+++ b/src/main/kotlin/world/cepi/itemextension/ItemExtension.kt
@@ -3,9 +3,11 @@ package world.cepi.itemextension
 import net.minestom.server.MinecraftServer
 import net.minestom.server.entity.Player
 import net.minestom.server.extensions.Extension
+import world.cepi.itemextension.combat.TargetHandler
 import world.cepi.itemextension.combat.events.*
 import world.cepi.itemextension.command.ClearCommand
 import world.cepi.itemextension.command.GiveCommand
+import world.cepi.itemextension.command.SpawnZombieCommand
 import world.cepi.itemextension.command.itemcommand.ItemCommand
 import world.cepi.itemextension.stats.StatsHandler
 
@@ -25,6 +27,7 @@ object ItemExtension : Extension() {
     override fun initialize() {
         val connectionManager = MinecraftServer.getConnectionManager()
         connectionManager.addPlayerInitialization(playerInitialization)
+        TargetHandler.register()
 
         MinecraftServer.getCommandManager().register(ItemCommand)
         MinecraftServer.getCommandManager().register(ClearCommand)

--- a/src/main/kotlin/world/cepi/itemextension/ItemExtension.kt
+++ b/src/main/kotlin/world/cepi/itemextension/ItemExtension.kt
@@ -32,6 +32,7 @@ object ItemExtension : Extension() {
         MinecraftServer.getCommandManager().register(ItemCommand)
         MinecraftServer.getCommandManager().register(ClearCommand)
         MinecraftServer.getCommandManager().register(GiveCommand)
+        MinecraftServer.getCommandManager().register(SpawnZombieCommand())
 
         logger.info("[ItemExtension] has been enabled!")
     }

--- a/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
+++ b/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
@@ -34,32 +34,33 @@ object TargetHandler {
                 val itemInHand = it.getItemInHand(Player.Hand.MAIN)
                 val itemInOffHand = it.getItemInHand(Player.Hand.OFF)
 
-                if((canTarget(itemInHand) || canTarget(itemInOffHand)) && it.instance != null) {
+                if((canTarget(itemInHand) || canTarget(itemInOffHand)) && it.instance != null) { // Check if the item supports the targeting system
                     // TODO: Base max distance upon the item
-                    val result = castRay(it.instance!!, it, Vector(it.position.x, it.position.y + it.eyeHeight, it.position.z), it.position.direction, 100.0, 0.25)
+                    val result = castRay(it.instance!!, it, Vector(it.position.x, it.position.y + it.eyeHeight, it.position.z), it.position.direction, 100.0, 0.25) // Cast a ray
 
+                    // Check if the ray has hit an entity
                     if(result.hitType == HitType.ENTITY) {
                         val target = result.hitEntity!!
-                        if(target is Player) {
+                        if(target is Player) { // Ignore if the entity hit is a player
                             return@forEach
                         }
 
-                        if(hasTarget(it)) {
+                        if(hasTarget(it)) { // Check if the player already has a target
                             val currentTarget = targets[it]!!
-                            if(currentTarget != target) {
+                            if(currentTarget != target) { // Switch target and update the entities' glow
                                 targets[it] = target
                                 PacketUtils.sendPacket(it, createMetadataPacket(currentTarget, false))
                                 PacketUtils.sendPacket(it, createMetadataPacket(target, true))
                             }
-                        } else {
+                        } else { // Set the target
                             targets[it] = target
                             PacketUtils.sendPacket(it, createMetadataPacket(target, true))
                         }
-                    } else if(hasTarget(it)) {
+                    } else if(hasTarget(it)) { // Remove target if no entity is hit
                         PacketUtils.sendPacket(it, createMetadataPacket(targets[it]!!, false))
                         targets.remove(it)
                     }
-                } else if(hasTarget(it)) {
+                } else if(hasTarget(it)) { // Remove target if the player swaps to an item which does not have targeting support
                     PacketUtils.sendPacket(it, createMetadataPacket(targets[it]!!, false))
                     targets.remove(it)
                 }
@@ -67,10 +68,21 @@ object TargetHandler {
         }.repeat(checkTarget, checkTargetTime).schedule()
     }
 
+    /**
+     * Get the [LivingEntity] that a [Player] is targeting
+     *
+     * @param player The [Player] which is targeting something
+     * @return a [LivingEntity] that is being targeted
+     */
     fun getTarget(player: Player): LivingEntity? {
         return targets[player]
     }
 
+    /**
+     * Check if a [Player] has a target
+     *
+     * @param player [Player] to check
+     */
     fun hasTarget(player: Player): Boolean {
         return targets.containsKey(player)
     }

--- a/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
+++ b/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
@@ -1,6 +1,5 @@
 package world.cepi.itemextension.combat
 
-import net.minestom.server.MinecraftServer
 import net.minestom.server.entity.Entity
 import net.minestom.server.entity.LivingEntity
 import net.minestom.server.entity.Metadata
@@ -8,12 +7,12 @@ import net.minestom.server.entity.Player
 import net.minestom.server.item.ItemStack
 import net.minestom.server.network.packet.server.play.EntityMetaDataPacket
 import net.minestom.server.utils.PacketUtils
-import net.minestom.server.utils.Vector
 import net.minestom.server.utils.time.TimeUnit
 import world.cepi.itemextension.item.Item
 import world.cepi.itemextension.item.checkIsItem
 import world.cepi.itemextension.item.module
 import world.cepi.itemextension.item.traits.list.attacks.AttackTrait
+import world.cepi.kstom.Manager
 import world.cepi.kstom.item.get
 import world.cepi.kstom.raycast.HitType
 import world.cepi.kstom.raycast.RayCast.castRay
@@ -28,45 +27,57 @@ object TargetHandler {
     private const val checkTarget = 1L
     private val checkTargetTime = TimeUnit.SECOND
 
-    fun register() {
-        MinecraftServer.getSchedulerManager().buildTask {
-            MinecraftServer.getConnectionManager().onlinePlayers.forEach {
-                val itemInHand = it.getItemInHand(Player.Hand.MAIN)
-                val itemInOffHand = it.getItemInHand(Player.Hand.OFF)
+    fun register() = Manager.scheduler.buildTask {
+        Manager.connection.onlinePlayers.forEach {
+            val itemInHand = it.itemInMainHand
+            val itemInOffHand = it.itemInOffHand
 
-                if((canTarget(itemInHand) || canTarget(itemInOffHand)) && it.instance != null) { // Check if the item supports the targeting system
-                    // TODO: Base max distance upon the item
-                    val result = castRay(it.instance!!, it, Vector(it.position.x, it.position.y + it.eyeHeight, it.position.z), it.position.direction, 100.0, 0.25) // Cast a ray
+            // Check if the item supports the targeting system
+            if ((canTarget(itemInHand) || canTarget(itemInOffHand)) && it.instance != null) {
 
-                    // Check if the ray has hit an entity
-                    if(result.hitType == HitType.ENTITY) {
-                        val target = result.hitEntity!!
-                        if(target is Player) { // Ignore if the entity hit is a player
-                            return@forEach
-                        }
+                // Cast a ray
+                // TODO: Base max distance upon the item
+                val result = castRay(
+                    it.instance!!,
+                    it,
+                    it.position.clone().add(.0, it.eyeHeight, .0).toVector(),
+                    it.position.direction,
+                    100.0,
+                    0.25
+                )
 
-                        if(hasTarget(it)) { // Check if the player already has a target
-                            val currentTarget = targets[it]!!
-                            if(currentTarget != target) { // Switch target and update the entities' glow
-                                targets[it] = target
-                                PacketUtils.sendPacket(it, createMetadataPacket(currentTarget, false))
-                                PacketUtils.sendPacket(it, createMetadataPacket(target, true))
-                            }
-                        } else { // Set the target
+                // Check if the ray has hit an entity
+                if (result.hitType == HitType.ENTITY) {
+
+                    val target = result.hitEntity!!
+
+                    // Ignore if the entity hit is a player
+                    if (target is Player) {
+                        return@forEach
+                    }
+
+                    if (hasTarget(it)) { // Check if the player already has a target
+                        val currentTarget = targets[it]!!
+                        if (currentTarget != target) { // Switch target and update the entities' glow
                             targets[it] = target
+                            PacketUtils.sendPacket(it, createMetadataPacket(currentTarget, false))
                             PacketUtils.sendPacket(it, createMetadataPacket(target, true))
                         }
-                    } else if(hasTarget(it)) { // Remove target if no entity is hit
-                        PacketUtils.sendPacket(it, createMetadataPacket(targets[it]!!, false))
-                        targets.remove(it)
+                    } else { // Set the target
+                        targets[it] = target
+                        PacketUtils.sendPacket(it, createMetadataPacket(target, true))
                     }
-                } else if(hasTarget(it)) { // Remove target if the player swaps to an item which does not have targeting support
+
+                } else if (hasTarget(it)) { // Remove target if no entity is hit
                     PacketUtils.sendPacket(it, createMetadataPacket(targets[it]!!, false))
                     targets.remove(it)
                 }
+            } else if (hasTarget(it)) { // Remove target if the player swaps to an item which does not have targeting support
+                PacketUtils.sendPacket(it, createMetadataPacket(targets[it]!!, false))
+                targets.remove(it)
             }
-        }.repeat(checkTarget, checkTargetTime).schedule()
-    }
+        }
+    }.repeat(checkTarget, checkTargetTime).schedule()
 
     /**
      * Get the [LivingEntity] that a [Player] is targeting
@@ -74,24 +85,23 @@ object TargetHandler {
      * @param player The [Player] which is targeting something
      * @return a [LivingEntity] that is being targeted
      */
-    fun getTarget(player: Player): LivingEntity? {
-        return targets[player]
-    }
+    fun getTarget(player: Player): LivingEntity? =
+        targets[player]
 
     /**
      * Check if a [Player] has a target
      *
      * @param player [Player] to check
      */
-    fun hasTarget(player: Player): Boolean {
-        return targets.containsKey(player)
-    }
+    fun hasTarget(player: Player): Boolean =
+        targets.containsKey(player)
 
     private fun canTarget(item: ItemStack): Boolean {
-        if(checkIsItem(item)) {
+        if (checkIsItem(item)) {
             val cepiItem: Item = item.meta.get(Item.key, module)!!
 
-            return cepiItem.traits.filterIsInstance<AttackTrait>().any { it.attack.requiresTarget } // Check if any attack of an item requires a target
+            // Check if any attack of an item requires a target
+            return cepiItem.traits.filterIsInstance<AttackTrait>().any { it.attack.requiresTarget }
         }
 
         return false
@@ -105,18 +115,19 @@ object TargetHandler {
         clonePacket.entityId = target.entityId
 
         val currentEntry = target.metadataPacket.entries.firstOrNull()
-        val mask = if (currentEntry != null && currentEntry.metaValue.value is Byte) {
-            modifyMask(0x40, glow, currentEntry.metaValue.value as Byte) // 0x40 being the bit for if an entity is glowing
-        } else {
-            modifyMask(0x40, glow) // Assume that no meta is present, thereby the current mask is 0
-        }
 
-        clonePacket.entries = Collections.singleton(Metadata.Entry(0, Metadata.Byte(mask))) as Collection<Metadata.Entry<*>>? // Weird mismatch, seems redundant but for some unknown reason it's required
+        // If no meta is present, the mask should be 0
+        val mask = modifyMask(0x40, glow, currentEntry?.metaValue?.value as? Byte ?: 0)
+
+        // Weird mismatch, seems redundant but for some unknown reason it's required
+        clonePacket.entries = Collections.singleton(Metadata.Entry(0, Metadata.Byte(mask))) as Collection<Metadata.Entry<*>>?
         return clonePacket
     }
 
     private fun modifyMask(bit: Byte, value: Boolean, currentMask: Byte = 0): Byte {
-        val currentValue = (currentMask and bit) == bit // Check if the currentMask "contains" the bit we want to set through bitwise operations.
+
+        // Check if the currentMask "contains" the bit we want to set through bitwise operations.
+        val currentValue = (currentMask and bit) == bit
         if (currentValue == value) {
             return currentMask
         }

--- a/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
+++ b/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
@@ -78,9 +78,7 @@ object TargetHandler {
         if(checkIsItem(item)) {
             val cepiItem: Item = item.meta.get(Item.key, module)!!
 
-            cepiItem.traits.forEach {
-                return it is AttackTrait && it.requiresTarget
-            }
+            return cepiItem.traits.filterIsInstance<AttackTrait>().any { it.attack.requiresTarget } // Check if any attack of an item requires a target
         }
 
         return false

--- a/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
+++ b/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
@@ -1,0 +1,119 @@
+package world.cepi.itemextension.combat
+
+import net.minestom.server.MinecraftServer
+import net.minestom.server.entity.Entity
+import net.minestom.server.entity.LivingEntity
+import net.minestom.server.entity.Metadata
+import net.minestom.server.entity.Player
+import net.minestom.server.item.ItemStack
+import net.minestom.server.network.packet.server.play.EntityMetaDataPacket
+import net.minestom.server.utils.PacketUtils
+import net.minestom.server.utils.Vector
+import net.minestom.server.utils.time.TimeUnit
+import world.cepi.itemextension.item.Item
+import world.cepi.itemextension.item.checkIsItem
+import world.cepi.itemextension.item.module
+import world.cepi.itemextension.item.traits.list.attacks.AttackTrait
+import world.cepi.kstom.item.get
+import world.cepi.kstom.raycast.HitType
+import world.cepi.kstom.raycast.RayCast.castRay
+import java.util.*
+import kotlin.experimental.and
+import kotlin.experimental.inv
+import kotlin.experimental.or
+
+object TargetHandler {
+    private val targets = mutableMapOf<Player, LivingEntity>()
+
+    private const val checkTarget = 1L
+    private val checkTargetTime = TimeUnit.SECOND
+
+    fun register() {
+        MinecraftServer.getSchedulerManager().buildTask {
+            MinecraftServer.getConnectionManager().onlinePlayers.forEach {
+                val itemInHand = it.getItemInHand(Player.Hand.MAIN)
+                val itemInOffHand = it.getItemInHand(Player.Hand.OFF)
+
+                if((canTarget(itemInHand) || canTarget(itemInOffHand)) && it.instance != null) {
+                    // TODO: Base max distance upon the item
+                    //val result = castRay(it.instance!!, it, it.position.x, it.position.y + it.eyeHeight, it.position.z, it.position.direction.x, it.position.direction.y, it.position.direction.z, 100.0, 0.25, { pos ->  it.instance!!.getBlockStateId(pos) == Block.AIR.blockId }, {})
+                    val result = castRay(it.instance!!, it, Vector(it.position.x, it.position.y + it.eyeHeight, it.position.z), it.position.direction, 100.0, 0.25)
+
+                    if(result.hitType == HitType.ENTITY) {
+                        val target = result.hitEntity!!
+                        if(target is Player) {
+                            return@forEach
+                        }
+
+                        if(hasTarget(it)) {
+                            val currentTarget = targets[it]!!
+                            if(currentTarget != target) {
+                                targets[it] = target
+                                PacketUtils.sendPacket(it, createMetadataPacket(currentTarget, false))
+                                PacketUtils.sendPacket(it, createMetadataPacket(target, true))
+                            }
+                        } else {
+                            targets[it] = target
+                            PacketUtils.sendPacket(it, createMetadataPacket(target, true))
+                        }
+                    } else if(hasTarget(it)) {
+                        val target = targets[it]!!
+                        targets.remove(it)
+                        PacketUtils.sendPacket(it, createMetadataPacket(target, false))
+                    }
+                }
+            }
+        }.repeat(checkTarget, checkTargetTime).schedule()
+    }
+
+    fun getTarget(player: Player): LivingEntity? {
+        return targets[player]
+    }
+
+    fun hasTarget(player: Player): Boolean {
+        return targets.containsKey(player)
+    }
+
+    private fun canTarget(item: ItemStack): Boolean {
+        if(checkIsItem(item)) {
+            val cepiItem: Item = item.meta.get(Item.key, module)!!
+
+            cepiItem.traits.forEach {
+                return it is AttackTrait && it.requiresTarget
+            }
+        }
+
+        return false
+    }
+
+
+    // All of the seemingly random constants here are a result of reverse engineering Minestom's metadata system
+    private fun createMetadataPacket(target: Entity, glow: Boolean): EntityMetaDataPacket {
+        // Clone the metadata packet to prevent sync issues
+        val clonePacket = EntityMetaDataPacket()
+        clonePacket.entityId = target.entityId
+
+        val currentEntry = target.metadataPacket.entries.firstOrNull()
+        val mask = if (currentEntry != null && currentEntry.metaValue.value is Byte) {
+            modifyMask(0x40, glow, currentEntry.metaValue.value as Byte) // 0x40 being the bit for if an entity is glowing
+        } else {
+            modifyMask(0x40, glow) // Assume that no meta is present, thereby the current mask is 0
+        }
+
+        clonePacket.entries = Collections.singleton(Metadata.Entry(0, Metadata.Byte(mask))) as Collection<Metadata.Entry<*>>? // Weird mismatch, seems redundant but for some unknown reason it's required
+        return clonePacket
+    }
+
+    private fun modifyMask(bit: Byte, value: Boolean, currentMask: Byte = 0): Byte {
+        val currentValue = (currentMask and bit) == bit // Check if the currentMask "contains" the bit we want to set through bitwise operations.
+        if (currentValue == value) {
+            return currentMask
+        }
+
+        return if (value) {
+            currentMask or bit // Add the bit to the mask
+        } else {
+            currentMask and bit.inv() // Remove the bit from the mask by adding the compliment of the bit
+        }
+    }
+}

--- a/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
+++ b/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
@@ -36,7 +36,6 @@ object TargetHandler {
 
                 if((canTarget(itemInHand) || canTarget(itemInOffHand)) && it.instance != null) {
                     // TODO: Base max distance upon the item
-                    //val result = castRay(it.instance!!, it, it.position.x, it.position.y + it.eyeHeight, it.position.z, it.position.direction.x, it.position.direction.y, it.position.direction.z, 100.0, 0.25, { pos ->  it.instance!!.getBlockStateId(pos) == Block.AIR.blockId }, {})
                     val result = castRay(it.instance!!, it, Vector(it.position.x, it.position.y + it.eyeHeight, it.position.z), it.position.direction, 100.0, 0.25)
 
                     if(result.hitType == HitType.ENTITY) {

--- a/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
+++ b/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
@@ -24,8 +24,8 @@ import kotlin.experimental.or
 object TargetHandler {
     private val targets = mutableMapOf<Player, LivingEntity>()
 
-    private const val checkTarget = 1L
-    private val checkTargetTime = TimeUnit.SECOND
+    private const val checkTarget = 5L
+    private val checkTargetTime = TimeUnit.TICK
 
     fun register() = Manager.scheduler.buildTask {
         Manager.connection.onlinePlayers.forEach {

--- a/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
+++ b/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
@@ -57,9 +57,8 @@ object TargetHandler {
                             PacketUtils.sendPacket(it, createMetadataPacket(target, true))
                         }
                     } else if(hasTarget(it)) {
-                        val target = targets[it]!!
+                        PacketUtils.sendPacket(it, createMetadataPacket(targets[it]!!, false))
                         targets.remove(it)
-                        PacketUtils.sendPacket(it, createMetadataPacket(target, false))
                     }
                 } else if(hasTarget(it)) {
                     PacketUtils.sendPacket(it, createMetadataPacket(targets[it]!!, false))

--- a/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
+++ b/src/main/kotlin/world/cepi/itemextension/combat/TargetHandler.kt
@@ -61,6 +61,9 @@ object TargetHandler {
                         targets.remove(it)
                         PacketUtils.sendPacket(it, createMetadataPacket(target, false))
                     }
+                } else if(hasTarget(it)) {
+                    PacketUtils.sendPacket(it, createMetadataPacket(targets[it]!!, false))
+                    targets.remove(it)
                 }
             }
         }.repeat(checkTarget, checkTargetTime).schedule()

--- a/src/main/kotlin/world/cepi/itemextension/item/traits/list/attacks/Attack.kt
+++ b/src/main/kotlin/world/cepi/itemextension/item/traits/list/attacks/Attack.kt
@@ -6,7 +6,7 @@ import net.minestom.server.entity.Player
 import net.minestom.server.sound.SoundEvent
 import net.minestom.server.entity.damage.DamageType
 
-enum class Attack(val displayName: String, val action: (Player, Player.Hand, LivingEntity) -> Boolean = { _, _, _ -> true } ) {
+enum class Attack(val displayName: String, val action: (Player, Player.Hand, LivingEntity) -> Boolean = { _, _, _ -> true }, val requiresTarget: Boolean = false) {
 
     STRIKE("Strike"),
     NONE("None", { _, _, _ -> false }),
@@ -22,6 +22,6 @@ enum class Attack(val displayName: String, val action: (Player, Player.Hand, Liv
     TARGET_ATTACK("Target Attack", { player, _, target ->
         target.damage(DamageType.fromPlayer(player), 1.0F)
         true
-    })
+    }, true)
 
 }

--- a/src/main/kotlin/world/cepi/itemextension/item/traits/list/attacks/Attack.kt
+++ b/src/main/kotlin/world/cepi/itemextension/item/traits/list/attacks/Attack.kt
@@ -1,20 +1,26 @@
 package world.cepi.itemextension.item.traits.list.attacks
 
 import net.kyori.adventure.sound.Sound
+import net.minestom.server.entity.LivingEntity
 import net.minestom.server.entity.Player
 import net.minestom.server.sound.SoundEvent
+import net.minestom.server.entity.damage.DamageType
 
-enum class Attack(val displayName: String, val action: (Player, Player.Hand) -> Boolean = { _, _ -> true } ) {
+enum class Attack(val displayName: String, val action: (Player, Player.Hand, LivingEntity) -> Boolean = { _, _, _ -> true } ) {
 
     STRIKE("Strike"),
-    NONE("None", { _, _ -> false }),
-    YEET("Yeet", { player, _ ->
+    NONE("None", { _, _, _ -> false }),
+    YEET("Yeet", { player, _, _ ->
         player.velocity.add(0.0, 20.0, 0.0)
         true
     }),
-    DASH("Dash", { player, _ ->
+    DASH("Dash", { player, _, _ ->
         player.velocity.add(player.position.direction.clone().normalize().multiply(6))
         player.playSound(Sound.sound(SoundEvent.ENTITY_PLAYER_ATTACK_SWEEP, Sound.Source.MASTER, 1f, 1f))
+        true
+    }),
+    TARGET_ATTACK("Target Attack", { player, _, target ->
+        target.damage(DamageType.fromPlayer(player), 1.0F)
         true
     })
 

--- a/src/main/kotlin/world/cepi/itemextension/item/traits/list/attacks/AttackTrait.kt
+++ b/src/main/kotlin/world/cepi/itemextension/item/traits/list/attacks/AttackTrait.kt
@@ -17,6 +17,7 @@ abstract class AttackTrait: ItemTrait() {
 
     open val attack: Attack = Attack.STRIKE
     open val clickType: String = "None"
+    open val requiresTarget: Boolean = false
 
     override val loreIndex = 2f
     override val taskIndex = 0f

--- a/src/main/kotlin/world/cepi/itemextension/item/traits/list/attacks/AttackTrait.kt
+++ b/src/main/kotlin/world/cepi/itemextension/item/traits/list/attacks/AttackTrait.kt
@@ -17,7 +17,6 @@ abstract class AttackTrait: ItemTrait() {
 
     open val attack: Attack = Attack.STRIKE
     open val clickType: String = "None"
-    open val requiresTarget: Boolean = false
 
     override val loreIndex = 2f
     override val taskIndex = 0f


### PR DESCRIPTION
This PR adds a system that allows players to target entities at a given range and provide clear visuals that show what a player is targeting through the use of the glow effect. A target can be used for a range of different things, but the most common use case will be for attacks.